### PR TITLE
coo upgrade testing pipeline on OCP4.16

### DIFF
--- a/.tekton/integration-tests/coo-fbc-upgrade-test-pipeline-4-16.yaml
+++ b/.tekton/integration-tests/coo-fbc-upgrade-test-pipeline-4-16.yaml
@@ -1,0 +1,309 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/task: "[upgrade, coo-e2e-tests]"
+  name: coo-fbc-upgrade-test-pipeline-416
+spec:
+  description: |
+    This pipeline automates the process of running end-to-end tests for COO
+    using a ROSA (Red Hat OpenShift Service on AWS) cluster. The pipeline provisions
+    the ROSA cluster, installs the COO using with fbc image, runs the tests, collects artifacts,
+    and finally deprovisions the ROSA cluster.
+  params:
+    - name: SNAPSHOT
+      description: 'The JSON string representing the snapshot of the application under test.'
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: namespace
+      description: 'Namespace to run tests in'
+      default: 'openshift-cluster-observability-operator'
+      type: string
+    - name: coo_tests_branch
+      description: 'E2E test branch'
+      default: 'release-1.2'
+      type: string
+    - name: coo_version
+      description: 'COO version'
+      default: '1.2.0'
+      type: string
+  tasks:
+    - name: eaas-provision-space
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: provision-cluster
+      runAfter:
+        - eaas-provision-space
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.16."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.2xlarge"
+              - name: timeout
+                value: "40m"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/cluster-observability-operator
+                    mirrors:
+                      - quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator
+    - name: coo-upgrade-install
+      description: Task to install bundle onto ephemeral namespace
+      runAfter:
+        - provision-cluster
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: namespace
+          value: "$(params.namespace)"
+        - name: coo_version
+          value: "$(params.coo_version)"
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: namespace
+          - name: coo_version
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: upgrade-operator
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: KONFLUX_COMPONENT_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/component']
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            script: |
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+
+              echo "Install dependencies"
+              dnf -y install jq python3-pip
+
+              coo_install_ns=$(params.namespace)
+              echo "Create namespace to install COO"
+              oc create namespace ${coo_install_ns}
+              oc label namespaces ${coo_install_ns} openshift.io/cluster-monitoring=true --overwrite=true
+
+              echo "Install coo production version"
+              export COO_INSTALL_PROD=https://raw.githubusercontent.com/rhobs/konflux-coo-fbc/refs/heads/main/.tekton/integration-tests/resources/coo-install-prod.yaml
+              curl -Lo /tmp/coo-install-prod.yaml "$COO_INSTALL_PROD"
+              oc apply -f /tmp/coo-install-prod.yaml
+
+              echo "Check coo install successfully"
+              oc -n "${coo_install_ns}" wait --for=condition=CatalogSourcesUnhealthy=False \
+              	subscription.operators.coreos.com cluster-observability-operator --timeout=120s
+              for i in {1..24}; do
+                if oc get deploy/obo-prometheus-operator -n "${coo_install_ns}" >/dev/null 2>&1; then
+                  echo "Deployment obo-prometheus-operator found"
+                  break
+                fi
+                echo "Waiting for deployment obo-prometheus-operator to be created..."
+                sleep 5
+              done
+              oc get deploy/obo-prometheus-operator -n "${coo_install_ns}"
+              oc wait -n "${coo_install_ns}" --for=condition=Available deploy/obo-prometheus-operator --timeout=300s
+              oc wait -n "${coo_install_ns}" --for=condition=Available deploy/obo-prometheus-operator-admission-webhook --timeout=300s
+              oc wait -n "${coo_install_ns}" --for=condition=Available deploy/observability-operator --timeout=300s
+              echo "coo install successfully"
+
+              echo "Get the FBC image"
+              echo ${KONFLUX_COMPONENT_NAME}
+              export FBC_IMAGE="$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT")"
+              echo "${FBC_IMAGE}"
+
+              echo "create catalogsource with FBC image"
+              export CATALOGSOURCE_TEMPLATE=https://raw.githubusercontent.com/rhobs/konflux-coo-fbc/refs/heads/main/.tekton/integration-tests/resources/catalogsource-template.yaml
+              curl -Lo /tmp/catalogsource-template.yaml "$CATALOGSOURCE_TEMPLATE"
+              oc process -f /tmp/catalogsource-template.yaml -p FBC_IMAGE=${FBC_IMAGE} | oc apply -n openshift-marketplace -f -
+
+              echo "Upgrade COO"
+              oc patch subscription cluster-observability-operator \
+                -n "${coo_install_ns}" \
+                --type=merge \
+                -p '{"spec": {"source": "coo"}}'
+
+              echo "Check coo upgrade successfully"
+              oc -n "${coo_install_ns}" wait --for=condition=CatalogSourcesUnhealthy=False \
+              	subscription.operators.coreos.com cluster-observability-operator --timeout=120s
+              coo_version=$(params.coo_version)
+              CSV_NAME="cluster-observability-operator.v${coo_version}"
+              for i in {1..24}; do
+                if oc get csv "${CSV_NAME}" -n "${coo_install_ns}" >/dev/null 2>&1; then
+                  echo "CSV ${CSV_NAME} found"
+                  break
+                fi
+                echo "Waiting for CSV ${CSV_NAME} to be created..."
+                sleep 5
+              done
+              oc get csv "${CSV_NAME}" -n "${coo_install_ns}"
+              oc wait -n "${coo_install_ns}" --for=condition=Available deploy/obo-prometheus-operator --timeout=300s
+              oc wait -n "${coo_install_ns}" --for=condition=Available deploy/obo-prometheus-operator-admission-webhook --timeout=300s
+              oc wait -n "${coo_install_ns}" --for=condition=Available deploy/observability-operator --timeout=300s
+              echo "coo upgrade successfully"
+    - name: coo-e2e-tests
+      description: Task to run tests from service repository
+      runAfter:
+        - coo-install
+      params:
+        - name: COO_TESTS_BRANCH
+          value: $(params.coo_tests_branch)
+        - name: namespace
+          value: "$(params.namespace)"
+      taskSpec:
+        params:
+          - name: COO_TESTS_BRANCH
+          - name: namespace
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: run-e2e-tests
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            script: |
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+              COO_TESTS_BRANCH=$(params.COO_TESTS_BRANCH)
+
+              echo "Intall dependencies"
+              dnf -y install jq vim unzip git make
+
+              echo "Install GO"
+              curl -Lo /go.tar.gz https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
+              tar -C /usr/local -xzf /go.tar.gz
+              export PATH=$PATH:/usr/local/go/bin
+              # Set the Go path and Go cache environment variables
+              export GOPATH=/tmp/go
+              export GOBIN=/tmp/go/bin
+              export GOCACHE=/tmp/.cache/go-build
+              export PATH=$PATH:/tmp/go/bin
+
+              # Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
+              mkdir -p /tmp/go/bin $GOCACHE \
+                && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
+              go version
+
+              echo "Install kubectl and oc"
+              cd /tmp/ \
+              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
+              && tar -xvzf oc.tar.gz \
+              && chmod +x kubectl oc \
+              && mv oc kubectl /usr/local/bin/
+
+              echo "Run e2e tests"
+              git clone https://github.com/rhobs/observability-operator.git /tmp/coo-tests
+              cd /tmp/coo-tests
+              git checkout $COO_TESTS_BRANCH
+              make build
+
+              # Execute coo e2e tests
+              coo_install_ns=$(params.namespace)
+              echo "/tmp/coo-tests/test/run-e2e.sh --no-deploy --ns \"$coo_install_ns\" --ci"
+              /tmp/coo-tests/test/run-e2e.sh --no-deploy --ns "$coo_install_ns" --ci

--- a/.tekton/integration-tests/resources/catalogsource-template.yaml
+++ b/.tekton/integration-tests/resources/catalogsource-template.yaml
@@ -1,0 +1,22 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: catalogsource-template
+parameters:
+- name: FBC_IMAGE
+  description: "Description of the parameter"
+  value: "default-value"
+  required: true
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: CatalogSource
+  metadata:
+    name: coo
+    namespace: openshift-marketplace
+  spec:
+    sourceType: grpc
+    image: ${FBC_IMAGE}
+    publisher: Openshift QE
+    updateStrategy:
+      registryPoll:
+        interval: 10m0s

--- a/.tekton/integration-tests/resources/coo-install-prod.yaml
+++ b/.tekton/integration-tests/resources/coo-install-prod.yaml
@@ -1,0 +1,23 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  namespace: openshift-cluster-observability-operator
+  name: og-global
+  labels:
+    og_label: openshift-cluster-observability-operator
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/observability-operator.openshift-operators: ""
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
[COO-847](https://issues.redhat.com/browse/COO-847) Add FBC upgrade test

The pipeline will complete the following
1. Provision an OCP 4.16 cluster ( the highest version konflux support is OCP 4.17 and bundle integration test run with OCP 4.17)
2. Install COO latest released version
3. Get FBC component image when there is a new build and upgrade coo with the image
4. Perform e2e-testing
